### PR TITLE
use no-remapped mapping commands

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -384,7 +384,7 @@ set nocompatible
             :exe 'bufdo! %s/\<' . expand('<cword>') . '\>/' . s:word . '/gce'
             :unlet! s:word
         endfunction
-        map <Leader>r :call Replace()<CR>
+        nnoremap <Leader>r :<C-u>call Replace()<CR>
 
     " <Esc><Esc>
         " Clear the search highlight in Normal mode
@@ -421,7 +421,7 @@ set nocompatible
             echo "Show no line numbers"
           endif
         endfunction
-        map <Leader>nm :call ToogleRelativeNumber()<cr>
+        nnoremap <Leader>nm :<C-u>call ToogleRelativeNumber()<cr>
 
     " ,g
         " Toggle GUI elements
@@ -435,33 +435,33 @@ set nocompatible
             echo "Show no GUI elements"
           endif
         endfunction
-        map <Leader>g <Esc>:call ToggleGUINoise()<cr>
+        nnoremap <Leader>g <Esc>:<C-u>call ToggleGUINoise()<cr>
 
     " ,f
         " Fast grep
         " Recursive search in current directory for matches with current word
-        map <Leader>f :execute "Ack " . expand("<cword>") <Bar> cw<CR>
+        nnoremap <Leader>f :<C-u>execute "Ack " . expand("<cword>") <Bar> cw<CR>
 
     " ,s
         " Shortcut for :%s//
-        nnoremap <leader>s :%s//<left>
+        nnoremap <leader>s :<C-u>%s//<left>
         vnoremap <leader>s :s//<left>
 
     " Move lines
         " Move one line
-        nmap <C-S-k> ddkP
-        nmap <C-S-j> ddp
+        nnoremap <C-S-k> ddkP
+        nnoremap <C-S-j> ddp
         " Move selected lines
         " See http://www.vim.org/scripts/script.php?script_id=1590
-        vmap <C-S-k> xkP'[V']
-        vmap <C-S-j> xp'[V']
+        vnoremap <C-S-k> xkP'[V']
+        vnoremap <C-S-j> xp'[V']
 
     " Y from cursor position to the end of line
         nnoremap Y y$
 
     " Pasting with correct indention
-        " nmap p p=`]
-        " nmap P P=`[
+        " nnoremap p p=`]
+        " nnoremap P P=`[
 
     " Disable <Arrow keys>
         " Warning: nightmare mode!
@@ -474,33 +474,33 @@ set nocompatible
         noremap <Left> <NOP>
         noremap <Right> <NOP>
         " Navigate with <Ctrl>-hjkl in Insert mode
-        imap <C-h> <C-o>h
-        imap <C-j> <C-o>j
-        imap <C-k> <C-o>k
-        imap <C-l> <C-o>l
+        inoremap <C-h> <C-o>h
+        inoremap <C-j> <C-o>j
+        inoremap <C-k> <C-o>k
+        inoremap <C-l> <C-o>l
 
     " Switch splits
-        nmap <C-h> <C-W>h
-        nmap <C-j> <C-W>j
-        nmap <C-k> <C-W>k
-        nmap <C-l> <C-W>l
+        nnoremap <C-h> <C-W>h
+        nnoremap <C-j> <C-W>j
+        nnoremap <C-k> <C-W>k
+        nnoremap <C-l> <C-W>l
 
     " ,v
         " Open the .vimrc in a new tab
-        nmap <leader>v :tabedit $MYVIMRC<CR>
+        nnoremap <leader>v :<C-u>tabedit $MYVIMRC<CR>
         :cabbrev e NERDTreeClose<CR>:e!
 
     " <Space> = <PageDown>
-        nmap <Space> <PageDown>
+        nnoremap <Space> <PageDown>
 
     " n и N
         " Search matches are always in center
-        nmap n nzz
-        nmap N Nzz
-        nmap * *zz
-        nmap # #zz
-        nmap g* g*zz
-        nmap g# g#zz
+        nnoremap n nzz
+        nnoremap N Nzz
+        nnoremap * *zz
+        nnoremap # #zz
+        nnoremap g* g*zz
+        nnoremap g# g#zz
 
     " K to split
         " Basically this splits the current line into two new ones at the cursor position,
@@ -528,13 +528,13 @@ set nocompatible
 
     " gf
         " Open file under cursor in a new vertical split
-        nmap gf :vertical wincmd f<CR>
+        nnoremap gf :<C-u>vertical wincmd f<CR>
 
     " Create a new window relative to the current one
-        nmap <Leader><left>  :leftabove  vnew<CR>
-        nmap <Leader><right> :rightbelow vnew<CR>
-        nmap <Leader><up>    :leftabove  new<CR>
-        nmap <Leader><down>  :rightbelow new<CR>
+        nnoremap <Leader><left>  :<C-u>leftabove  vnew<CR>
+        nnoremap <Leader><right> :<C-u>rightbelow vnew<CR>
+        nnoremap <Leader><up>    :<C-u>leftabove  new<CR>
+        nnoremap <Leader><down>  :<C-u>rightbelow new<CR>
 
     " Copy indented line without spaces
         nnoremap ,y ^yg_"_dd
@@ -545,23 +545,23 @@ set nocompatible
 
     " <Space><Space>
         " Double space to ". "
-        " imap <Space><Space> . 
+        " inoremap <Space><Space> . 
 
     " ,ts
         " Fix trailing white space
-        map <leader>ts :%s/\s\+$//e<CR>
+        nnoremap <leader>ts :<C-u>%s/\s\+$//e<CR>
 
     " ,bl
         " Show buffers
-        nmap <Leader>bl :ls<cr>:b
+        nnoremap <Leader>bl :<C-u>ls<cr>:b
 
     " ,bp
         " Go to prev buffer
-        nmap <Leader>bp :bp<cr>
+        nnoremap <Leader>bp :<C-u>bp<cr>
 
     " ,bn
         " Go to next buffer
-        nmap <Leader>bn :bn<cr>
+        nnoremap <Leader>bn :<C-u>bn<cr>
 
     " ,u
         " Change case to uppercase
@@ -571,25 +571,25 @@ set nocompatible
     " В коммандном режиме разрешить прыгать в конец и начало строки,
     " как в консоли
         cnoremap <c-e> <end>
-        imap     <c-e> <c-o>$
+        inoremap     <c-e> <c-o>$
         cnoremap <c-a> <home>
-        imap     <c-a> <c-o>^
+        inoremap     <c-a> <c-o>^
 
     " ,b
         " In Visual mode exec git blame with selected text
-        vmap <Leader>b :<C-U>!git blame <C-R>=expand("%:p") <CR> \| sed -n <C-R>=line("'<") <CR>,<C-R>=line("'>") <CR>p <CR>
+        vnoremap <Leader>b :<C-U>!git blame <C-R>=expand("%:p") <CR> \| sed -n <C-R>=line("'<") <CR>,<C-R>=line("'>") <CR>p <CR>
 
     " ,w
         " Jump to next split
-        map <Leader>w <C-w>w
+        nnoremap <Leader>w <C-w>w
 
     " Ctrl+s
-        map <C-s> <esc>:w<CR>
-        imap <C-s> <esc>:w<CR>
+        noremap <C-s> <esc>:w<CR>
+        inoremap <C-s> <esc>:w<CR>
 
     " ,n
         " Edit another file in the same directory with the current one
-        map <Leader>n :vnew <C-R>=expand("%:p:h") . '/'<CR>
+        noremap <Leader>n :<C-u>vnew <C-R>=expand("%:p:h") . '/'<CR>
 
     " Bind :Q to :q
         command! Q q
@@ -605,8 +605,8 @@ set nocompatible
         " vnoremap <Space> zf
 
     " Switch tabs with <Tab>
-        nmap <Tab> gt
-        nmap <S-Tab> gT
+        nnoremap <Tab> gt
+        nnoremap <S-Tab> gT
 
     " Ремапим русские символы
         " set langmap=ёйцукенгшщзхъфывапролджэячсмитьбюЁЙЦУКЕHГШЩЗХЪФЫВАПРОЛДЖЭЯЧСМИТЬБЮ;`qwertyuiop[]asdfghjkl\\;'zxcvbnm\\,.~QWERTYUIOP{}ASDFGHJKL:\\"ZXCVBNM<>
@@ -693,7 +693,7 @@ set nocompatible
         endtry
 
     " NERDTree
-        nmap <Bs> :NERDTreeToggle<CR>
+        nnoremap <Bs> :<C-u>NERDTreeToggle<CR>
         let NERDTreeShowBookmarks=1
         let NERDTreeChDirMode=2
         let NERDTreeQuitOnOpen=1


### PR DESCRIPTION
This pull request fixes `nmap` to `nnoremap`.

Reasoning:
If we do not use no-remapped commands like `map`, `nmap`, `imap` etc., the mappings are again remapped. For example, when we use the settings
```vim
nnoremap : ;
nnoremap ; :
```
in order to swap the colon and semicolon (so that we need not press shift again and again), the mapping
```vim
map <leader>ts :%s/\s\+$//e<CR>
```
get affected and is remapped to
```vim
;%s/\s\+$//e<CR>
```
This causes an error. Another reason why noremapped commands are preferable is that the settings like the following will cause an error `E223: recursive mapping`.
```vim
nmap : ;
nmap ; :
```

Also, this pull request uses `<C-u>` to clear the ranges for commands which does not accept ranges.
For example, assume that we use the following setting
```vim
nnoremap <leader>ts :%s/\s\+$//e<CR>
```
When we mistakenly type as `5<leader>ts`, the command line becomes `.,.+4%s/\s\+$//e`, which causes an error. This is why we have to clear the ranges.